### PR TITLE
[#7] Custom Errors for runEIO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
 
     - name: Test
       run: |
-        cabel test
+        cabal test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
 
     - name: Test
       run: |
-        echo 'No tests'
+        cabel test

--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,14 @@ cabal.project.local
 .ghc.environment.*
 .HTF/
 .hie/
+ghcid.txt
+
 # Stack
 .stack-work/
 stack.yaml.lock
+
+# Nix
+shell.nix
 
 ### IDE/support
 # Vim

--- a/eio.cabal
+++ b/eio.cabal
@@ -64,6 +64,19 @@ library
   import:              common-options
   hs-source-dirs:      src
   exposed-modules:     EIO
+                     , EIO.TypeErrors
+
+test-suite eio-doctest
+  import:              common-options
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Doctest.hs
+
+  build-depends:       eio
+                     , doctest
+                     , Glob
+
+  ghc-options:         -threaded
 
 executable readme
   import:              common-options

--- a/src/EIO.hs
+++ b/src/EIO.hs
@@ -76,9 +76,9 @@ ran action
 
 >>> EIO.runEIO $ EIO.throw MyErr >> EIO.return ()
 ...
-... The 'runEIO' handler requires that all exceptions in 'EIO' to be handled.
-    The action 'runEIO' is applied to throws the following unhandled exceptions:
-      • MyErr
+... • The 'runEIO' handler requires that all exceptions in 'EIO' to be handled.
+...   The action 'runEIO' is applied to throws the following unhandled exceptions:
+...     • MyErr
 ...
 
 @since 0.0.0.0

--- a/src/EIO.hs
+++ b/src/EIO.hs
@@ -34,6 +34,10 @@ import EIO.TypeErrors (DisallowUnhandledExceptions)
 import qualified GHC.IO as IO
 import qualified Prelude
 
+-- $setup
+-- >>> import qualified EIO as EIO
+-- >>> data MyErr = MyErr deriving (Show)
+-- >>> instance Exception MyErr
 
 {- | Main type for 'IO' that tracks exceptions on the
 type-level. Simply wraps 'IO' and adds exceptions meta-information.
@@ -61,11 +65,26 @@ safeMain = EIO.do
     ... your code ...
 @
 
+>>> :{
+  EIO.runEIO $ EIO.do
+    EIO.throw MyErr `EIO.catch` (\MyErr -> (EIO $ putStrLn "handled error") >> EIO.return ())
+    EIO $ putStrLn "ran action"
+    EIO.return ()
+>>> :}
+handled error
+ran action
+
+>>> EIO.runEIO $ EIO.throw MyErr >> EIO.return ()
+...
+... The 'runEIO' handler requires that all exceptions in 'EIO' to be handled.
+    The action 'runEIO' is applied to throws the following unhandled exceptions:
+      • MyErr1
+...
+
 @since 0.0.0.0
 -}
 runEIO :: DisallowUnhandledExceptions excepts => EIO excepts () -> IO ()
 runEIO = coerce
-
 
 {- | Wrap a value into 'EIO' without throwing any exceptions.
 

--- a/src/EIO.hs
+++ b/src/EIO.hs
@@ -27,8 +27,10 @@ module EIO
 import Prelude hiding (return, (>>), (>>=))
 
 import Control.Exception (Exception)
+import Control.Monad
 import Data.Coerce (coerce)
-import Data.Kind (Type)
+import Data.Kind (Type, Constraint)
+import GHC.TypeLits
 
 import qualified GHC.IO as IO
 import qualified Prelude
@@ -62,8 +64,39 @@ safeMain = EIO.do
 
 @since 0.0.0.0
 -}
-runEIO :: EIO '[] () -> IO ()
+runEIO :: DisallowUnhandledExceptions excepts => EIO excepts () -> IO ()
 runEIO = coerce
+
+type family DisallowUnhandledExceptions (excepts :: [Type]) :: Constraint where
+    DisallowUnhandledExceptions '[]     = ()
+    DisallowUnhandledExceptions excepts =
+      TypeError
+        (     'Text "The 'runEIO' handler requires that all exceptions in 'EIO' to be handled."
+        ':$$: 'Text "The action 'runEIO' is applied to throws the following unhandled exceptions:"
+        ':$$: ShowTypeList excepts
+        )
+
+type family ShowTypeList (xs :: [Type]) :: ErrorMessage where
+    ShowTypeList '[] = 'Text ""
+    ShowTypeList (x ': xs) = 'Text "\t• " ':<>: ('ShowType x) ':$$: (ShowTypeList xs)
+
+data MyErr1 = MyErr1 deriving (Show)
+
+instance Exception MyErr1
+
+data MyErr2 = MyErr2 deriving (Show)
+
+instance Exception MyErr2
+
+data MyErr3 = MyErr3 deriving (Show)
+
+instance Exception MyErr3
+
+safeMainWrong :: IO ()
+safeMainWrong = runEIO errorsAbound
+  where
+    -- errorsAbound :: EIO '[MyErr1, MyErr2, MyErr3] ()
+    errorsAbound = (throw MyErr1) EIO.>> (throw MyErr2) EIO.>> (throw MyErr3)
 
 {- | Wrap a value into 'EIO' without throwing any exceptions.
 

--- a/src/EIO/TypeErrors.hs
+++ b/src/EIO/TypeErrors.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module EIO.TypeErrors
+  (DisallowUnhandledExceptions)
+   where
+
+import Data.Kind (Type, Constraint)
+import GHC.TypeLits
+
+type family DisallowUnhandledExceptions (excepts :: [Type]) :: Constraint where
+    DisallowUnhandledExceptions '[]     = ()
+    DisallowUnhandledExceptions excepts =
+      TypeError
+        (     'Text "The 'runEIO' handler requires that all exceptions in 'EIO' to be handled."
+        ':$$: 'Text "The action 'runEIO' is applied to throws the following unhandled exceptions:"
+        ':$$: ShowTypeList excepts
+        )
+
+type family ShowTypeList (xs :: [Type]) :: ErrorMessage where
+    ShowTypeList '[] = 'Text ""
+    ShowTypeList (x ': xs) = 'Text "\t• " ':<>: ('ShowType x) ':$$: (ShowTypeList xs)

--- a/src/EIO/TypeErrors.hs
+++ b/src/EIO/TypeErrors.hs
@@ -21,4 +21,4 @@ type family DisallowUnhandledExceptions (excepts :: [Type]) :: Constraint where
 
 type family ShowTypeList (xs :: [Type]) :: ErrorMessage where
     ShowTypeList '[] = 'Text ""
-    ShowTypeList (x ': xs) = 'Text "\t• " ':<>: ('ShowType x) ':$$: (ShowTypeList xs)
+    ShowTypeList (x ': xs) = 'Text "  • " ':<>: ('ShowType x) ':$$: (ShowTypeList xs)

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -1,0 +1,20 @@
+module Main (main) where
+
+import EIO
+
+import System.FilePath.Glob (glob)
+import Test.DocTest (doctest)
+
+main :: IO ()
+main = do
+    sourceFiles <- glob "src/**/*.hs"
+    doctest
+        $ "-XInstanceSigs"
+        : "-XNoImplicitPrelude"
+        : "-XOverloadedStrings"
+        : "-XScopedTypeVariables"
+        : "-XTypeApplications"
+        : "-XDerivingStrategies"
+        : "-XGeneralizedNewtypeDeriving"
+        : "-XQualifiedDo"
+        : sourceFiles


### PR DESCRIPTION
This haskell code generates the corresponding type error:
```haskell
data MyErr1 = MyErr1 deriving (Show)
instance Exception MyErr1

data MyErr2 = MyErr2 deriving (Show)
instance Exception MyErr2

data MyErr3 = MyErr3 deriving (Show)
instance Exception MyErr3

safeMainWrong :: IO ()
safeMainWrong = runEIO errorsAbound
  where
    errorsAbound = (throw MyErr1) EIO.>> (throw MyErr2) EIO.>> (throw MyErr3)
```
```idris
rc/EIO.hs:96:17: error:
    • The 'runEIO' handler requires that all exceptions in 'EIO' to be handled.
      The action 'runEIO' is applied to throws the following unhandled exceptions:
      	• MyErr1
      	• MyErr2
      	• MyErr3

    • In the expression: runEIO errorsAbound
      In an equation for ‘safeMainWrong’:
          safeMainWrong
            = runEIO errorsAbound
            where
                errorsAbound
                  = (throw MyErr1) EIO.>> (throw MyErr2) EIO.>> (throw MyErr3)
   |
96 | safeMainWrong = runEIO errorsAbound
   |                 ^^^^^^^^^^^^^^^^^^^
```